### PR TITLE
SWI-259 - replace ursa dependency with node-rsa

### DIFF
--- a/operations.js
+++ b/operations.js
@@ -4,7 +4,7 @@ var url = require('url');
 var crypto = require('crypto');
 var exec = require('child_process').exec;
 var _ = require("lodash");
-var key = require('ursa').coercePrivateKey;
+var NodeRSA = require('node-rsa');
 
 exports.operations = function(config){
     return {
@@ -25,7 +25,7 @@ exports.operations = function(config){
                 return header.join(":");
             }).join("\n");
 
-            var signature = key(config.key_contents).privateEncrypt(request_headers, 'utf8', 'base64');
+            var signature = new NodeRSA(config.key_contents).encryptPrivate(request_headers, 'base64', 'utf8');
 
             var auth_headers = {
                 "Accept": "application/json",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chef-api",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "A simple chef server api wrapper",
   "author": "Norman Joyner <norman.joyner@gmail.com>",
   "license": "GPLv2",
@@ -12,8 +12,8 @@
   },
   "dependencies": {
     "lodash": "^4.17.4",
-    "request": "^2.63.0",
-    "ursa": "^0.9.4"
+    "node-rsa": "^0.4.2",
+    "request": "^2.63.0"
   },
   "engines": {
     "node": "*"


### PR DESCRIPTION
https://jira.brandingbrand.com/browse/SWI-259

This is the first of 2 PRs that if successful will allow btool to run on node 6. This PR will have to be merged first before the 2nd pr can go in.

Btool can't run on node 6 or greater because the "ursa" module which does private key encryption has a dependency on module "nan" which blows up on 6. Swapping for "node-rsa" which appears to be more actively maintained and runs fine on 6.  This change should only affect the launch-elb command so that is all that should have to be tested.

Also adding version bump to facilitate update in btool's package.json.

to test:
- clone the btool repo to local
- delete the shrinkwrap file
- in package.json replace the ref to chef-api with the path to my feature branch
`"chef-api": "git+https://3b3b9c72c577c55f9f96ca534b4feda7d81b11e3:x-oauth-basic@github.com/jonkoynok/chef-api.git#SWI-259"`
   
- use node 6 and run npm install
- test the launch-elb command by running it local with "node btool launch-elb ...."

expected: command works